### PR TITLE
Fix compat with Webpack 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,13 @@
 var buble = require('buble');
 
 module.exports = function BubleLoader(source, inputSourceMap) {
-    var transformed = buble.transform(source);
+    var transformed = buble.transform(source, {
+        transforms: {
+            modules: false
+        }
+    });
 
     this.cacheable && this.cacheable();
-    this.value = source;
 
     return transformed.code;
 };


### PR DESCRIPTION
1. Disable Buble's module transform so it doesn't throw errors on module import/exports;
2. Remove the line that sets `this.value`, as in Webpack 2 `this` inside loaders is not extensible and this line will throw an error.
