### PR TITLE
bump buble peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/sairion/buble-loader/issues"
   },
   "peerDependencies": {
-    "buble": "^0.7.0",
+    "buble": "^0.12.0",
     "webpack": "1 || ^2.1.0-beta"
   },
   "devDependencies": {

--- a/test/fixtures/SyntaxCheck.js
+++ b/test/fixtures/SyntaxCheck.js
@@ -1,12 +1,14 @@
 'use strict';
 
 module.exports = {
-    /*
-    // NOT WORKING
-    objectDestructuring({ a, b, c } = {}) {
-        return [a, b, c];
+
+    objectDestructuring({ a, b, c } = {a: 1, b: '2', c: null}) {
+        console.assert(a === 1);
+        console.assert(b === '2');
+        console.assert(c === null);
+
+        return 'objectDestructuring(): ok';
     },
-    */
     blockScopingBindings() {
         let a = 1;
         {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,6 +1,6 @@
 var SyntaxCheck = require('./SyntaxCheck');
 
-// SyntaxCheck.objectDestructuring();
+console.log(SyntaxCheck.objectDestructuring());
 console.log(SyntaxCheck.blockScopingBindings());
 console.log(SyntaxCheck.arrowFunction());
 console.log(SyntaxCheck.untaggedTemplateString('world'));


### PR DESCRIPTION
Upgrade buble peer dep to `0.12.0`.
Also include the commented test, since it is passing now.
