### PR TITLE
Resolving peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buble-loader",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "lightweight ES2015 source loader for Webpack using Buble",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "url": "https://github.com/sairion/buble-loader/issues"
   },
   "peerDependencies": {
-    "buble": "^0.12.0",
+    "buble": ">=0.12.0",
     "webpack": "1 || ^2.1.0-beta"
   },
   "devDependencies": {


### PR DESCRIPTION
Upon installation, `buble-loader` complains about unmet peer dependency, because Bublé is now ahead at `0.13.1`. Since it's expected that Bublé undergoes new revisions relatively quickly, and `buble-loader` is somewhat experimental and isn't necessarily synchronized with Bublé, it can be useful if the install doesn't yield warnings on a new Bublé revision bump. PR can be thrown away if there are good reasons not to be permissive.
