### PR TITLE
Improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,16 @@ var buble = require('buble');
 var path = require('path');
 
 module.exports = function BubleLoader(source, inputSourceMap) {
-    var transformed = buble.transform(source, {
-        transforms: {
-            modules: false
-        }
-    });
+    try {
+        var transformed = buble.transform(source, {
+            transforms: {
+                modules: false
+            }
+        });
+    } catch (e) {
+        this.emitError(e)
+        return
+    }
     var resourcePath = this.resourcePath;
 
     transformed.map.file = resourcePath;

--- a/index.js
+++ b/index.js
@@ -2,18 +2,27 @@
 
 var buble = require('buble');
 var path = require('path');
+var assign = require('object-assign');
 
 module.exports = function BubleLoader(source, inputSourceMap) {
-    try {
-        var transformed = buble.transform(source, {
-            transforms: {
-                modules: false
-            }
-        });
-    } catch (e) {
-        this.emitError(e)
-        return
+    var options = {
+        transforms: {
+            modules: false
+        },
+        objectAssign: 'Object.assign'
+    };
+
+    if (this.options.buble) {
+        assign(options, this.options.buble);
     }
+
+    try {
+        var transformed = buble.transform(source, options);
+    } catch (e) {
+        this.emitError(e);
+        return '';
+    }
+
     var resourcePath = this.resourcePath;
 
     transformed.map.file = resourcePath;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/sairion/buble-loader/issues"
   },
   "peerDependencies": {
-    "buble": "^0.12.0",
+    "buble": "^0.13.0",
     "webpack": "1 || ^2.1.0-beta"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "bugs": {
     "url": "https://github.com/sairion/buble-loader/issues"
   },
+  "dependencies": {
+    "object-assign": "^4.0.1"
+  },
   "peerDependencies": {
     "buble": "^0.13.0",
     "webpack": "1 || ^2.1.0-beta"
-  },
-  "devDependencies": {
-    "object-assign": "^4.0.1"
   }
 }


### PR DESCRIPTION
- bump buble to 0.13.x
- better compilation error reporting (previously it just throws "Error" with no message)
- set default `objectAssign` option so rest spread works out of the box (requires user-installed `Object.assign` polyfill)
- support customizing the transform via the `buble` option in webpack config
