### PR TITLE
Allow buble global options

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function BubleLoader(source, inputSourceMap) {
             transforms: {
                 modules: false
             }
-        }, loaderOptions));
+        }, this.options.buble, loaderOptions));
     } catch (err) {
         handleError(err);
     }


### PR DESCRIPTION
like

``` javascript
module: {
  loaders: [
    {
      test: /.js$/,
      loaders: 'buble',
      include: path.join(__dirname, 'src')
    }
  ]
},
buble: {
  objectAssign: 'Object.assign'
}
```
