### PR TITLE
You shouldn't call parseQuery if it's already an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function handleError (err) {
 }
 
 module.exports = function BubleLoader(source, inputSourceMap) {
-    var loaderOptions = loaderUtils.parseQuery(this.query);
+    var loaderOptions = typeof this.query === 'string' ? loaderUtils.parseQuery(this.query) : this.query;
     var transformed;
     try {
         transformed = buble.transform(source, Object.assign({


### PR DESCRIPTION
https://github.com/webpack/loader-utils/commit/2c4728b1538c1df129b8b772c06353a7eede5236