### PR TITLE
Move buble, webpack to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   "devDependencies": {
     "object-assign": "^4.0.1"
   },
-  "dependencies": {
+  "peerDependencies": {
     "buble": "^0.15.0",
-    "loader-utils": "^0.2.15",
-    "webpack": "*"
+    "webpack": "*"    
+  },
+  "dependencies": {
+    "loader-utils": "^0.2.15"
   }
 }


### PR DESCRIPTION
According to https://webpack.js.org/development/how-to-write-a-loader/#use-a-library-as-peerdependencies-when-they-wrap-it, and loaders from https://github.com/webpack-contrib, `buble` and `webpack` should be listed as `peerDependencies`.