### PR TITLE
add escape to loader test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your `webpack.config.js`
 module: {
   loaders: [
     {
-      test: /.js$/,
+      test: /\.js$/,
       loaders: 'buble-loader',
       include: path.join(__dirname, 'src'),
       query: {


### PR DESCRIPTION
escape the `.` in `test: /.js$/` so it doesn't attempt to parse `.ejs` files