### PR TITLE
README: fix buble website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # buble-loader
 
-This package allows you to transpile ES2015 source using [buble](https://gitlab.com/Rich-Harris/buble). See [Buble project website](https://buble.surge.sh/guide/) to check out supported features.
+This package allows you to transpile ES2015 source using [buble](https://github.com/Rich-Harris/buble). See [Buble project website](https://buble.surge.sh/guide/) to check out supported features.
 
 note: This is almost-working prototype. Everything is immature. If you want something to be fixed, freely send PR or post issues!
 


### PR DESCRIPTION
buble migrated from GitLab to GitHub.