### PR TITLE
Fixed err when loaderUtils.getOptions return null

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class BubleError extends Error {
 }
 
 module.exports = function(source) {
-	const config = loaderUtils.getOptions(this);
+	const config = loaderUtils.getOptions(this) || {};
 	config.transforms = Object.assign({}, config.transforms || {}, { modules: false });
 	let output;
 	try {


### PR DESCRIPTION
As https://www.npmjs.com/package/loader-utils#getoptions said: "In any other case, it just returns `null`".
So it may be `null` and cause error in: https://github.com/sairion/buble-loader/blob/d0b63f8b86874cd6a6db0336e2e681390cb47486/index.js#L18
Thanks.